### PR TITLE
Remove running build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,7 @@ This repository contains a simple GitHub Action implementation, which allows you
 
 ## Enabling the action
 
-There are two steps required to use this action:
-
-* Enable the action inside your repository.
-  * This will mean creating a file `.github/workflows/release.yml` which is where the action is invoked, specifying a pattern to describe which binary-artifacts are uploaded.
-* Add your project-specific `.github/build` script.
-  * This is the script which will generate the files this action will upload.
-    * A C-project might just run `make`.
-    * A golang-based project might run `go build .` multiple times for different architectures.
+Enable the action inside your repository by creating a file `.github/workflows/release.yml` which is where the action is invoked, specifying a pattern to describe which binary-artifacts are uploaded.
 
 
 ## Sample Configuration
@@ -37,7 +30,7 @@ jobs:
         args: 'puppet-summary-*'
 ```
 
-We assume that the `.github/build` script generated suitable binaries.  For example a go-based project might create files like this using cross-compilation:
+We assume that the binaries are already created.  For example a go-based project might create files like this using cross-compilation:
 
 * `puppet-summary-linux-i386`
 * `puppet-summary-linux-amd64`

--- a/upload-script
+++ b/upload-script
@@ -25,15 +25,6 @@ if [ "$IS_DRAFT" = true ]; then
   exit 0
 fi
 
-# Run the build-script
-if [ -e .github/build ]; then
-    chmod 755 .github/build
-    ./.github/build
-else
-    echo "Missing build-script!"
-    exit 1
-fi
-
 # Prepare the headers
 AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 


### PR DESCRIPTION
Hi @skx,

First of all: great Action! I really like the idea to kick of a release on the GitHub UI, just what I was looking for.

My only gripe is that I think it does more than it should. If the purpose is to upload release artifacts, then we can assume the release artifacts have been built by another action. Before uploading we may even want to run tests, run code obfuscator (e.g. java projects), etc.

My scenario:
1. build a Ren'Py project (using image from DockerHub) and put the build artifacts in the `$GITHUB_WORKSPACE/dist/` folder
2. upload `$GITHUB_WORKSPACE/dist/*`

I would suggest uploading the build image to DockerHub (until GitHub Package Registry is released at least) as well, GitHub seems to download it faster than it can build.

I'll also try to create a golang:alpine version to reduce the image size.