### PR TITLE
Abort if upload returns a non 200 http status

### DIFF
--- a/upload-script
+++ b/upload-script
@@ -103,18 +103,31 @@ for file in $*; do
     tmp=$(mktemp)
 
     # Upload the file - capturing the output
-    curl \
+    response=$(curl \
         -sSL \
         -XPOST \
         -H "${AUTH_HEADER}" \
         --upload-file "${file}" \
         --header "Content-Type:application/octet-stream" \
-        "${UPLOAD_URL}"  2>&1 > $tmp
+        --write-out "%{http_code}" \
+        --output $tmp \
+        "${UPLOAD_URL}")
 
     # If the curl-command returned a non-zero response we must abort
     if [ "$?" -ne 0 ]; then
         echo "**********************************"
         echo " curl command did not return zero."
+        echo " Aborting"
+        echo "**********************************"
+        cat $tmp
+        rm $tmp
+        exit 1
+    fi
+
+    # If upload is not successful, we must abort
+    if [ $response -ne 200 ]; then
+        echo "**********************************"
+        echo " upload was not successful."
         echo " Aborting"
         echo "**********************************"
         cat $tmp


### PR DESCRIPTION
@skx - curl returning a non zero exit code does not happen if the GitHub upload request times out, or as mentioned in #6 , is a 404. I think both cases (curl exiting with non zero and post not being successful) should be handled. WDYT?