### PR TITLE
Fix upload script to check for error status

### DIFF
--- a/upload-script
+++ b/upload-script
@@ -122,11 +122,12 @@ for file in $*; do
     fi
 
     # If upload is not successful, we must abort
-    if [ $response -ne 200 ]; then
+    if [ $response -ge 400 ]; then
         echo "***************************"
         echo " upload was not successful."
         echo " Aborting"
-        echo "***************************"
+        echo " HTTP status is $response"
+        echo "**********************************"
         cat $tmp
         rm $tmp
         exit 1


### PR DESCRIPTION
@skx - so sorry, I was still verifying the success response when the last PR got merged. Locally, I had used another server to check it. GitHub returns 201, not 200 for upload being successful. So, this script was failing after successfully uploading the first artifact. Really sorry about the inconvenience

I have verified below:

- Successful upload (current master): https://github.com/varshavaradarajan/clusterlint/commit/7426641cc56485566e8c469f9d3e4dfa6e47be8b/checks?check_suite_id=264394796

- Successful upload (this PR): https://github.com/varshavaradarajan/clusterlint/commit/7426641cc56485566e8c469f9d3e4dfa6e47be8b/checks?check_suite_id=264410111

- Failure to upload: https://github.com/varshavaradarajan/clusterlint/commit/7426641cc56485566e8c469f9d3e4dfa6e47be8b/checks?check_suite_id=264416945

Cherrypicked from varshavaradarajan/github-action-publish-binaries@master to create this PR. I used varshavaradarajan/github-action-publish-binaries@master to verify the above. 