### PR TITLE
13 drop legacy build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository contains a simple GitHub Action implementation which allows you to attach binaries to a new (github) release of your repository.
 
+* [GitHub Action for Uploading Release Artifacts](#github-action-for-uploading-release-artifacts)
+  * [Enabling the action](#enabling-the-action)
+  * [Sample Configuration](#sample-configuration)
+  * [GITHUB_TOKEN](#github_token)
+
 
 ## Enabling the action
 
@@ -12,14 +17,11 @@ There are two steps required to use this action:
   * You'll specify a pattern to describe which binary-artifacts are uploaded.
 * Ensure your binary artifacts are generated.
   * Ideally you should do this in your workflow using another action.
-  * But if you're in a hurry you can add a project-specific `.github/build` script.
 
 
-## Sample Configuration: Preferred
+## Sample Configuration
 
-The following configuration file uses this action, along with another to build a project.
-
-This is the preferred approach:
+The following configuration file uses _this_ action, along with the [github-action-build](https://github.com/skx/github-action-build) action to generate the artifacts for a project, then attach them to a release.
 
 ```
 on:
@@ -33,9 +35,9 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master
-      - name: Generate artifacts
+      - name: Generate the artifacts
         uses: skx/github-action-build@master
-      - name: Upload artifacts
+      - name: Upload the artifacts
         uses: skx/github-action-publish-binaries@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -51,56 +53,9 @@ This is the preferred approach because it uses a pair of distinct actions, each 
 * [skx/github-action-publish-binaries](https://github.com/skx/github-action-publish-binaries)
   * Uploads the previously-generated the build artifacts.
 
-**NOTE**: Please see the note about GITHUB_TOKEN later.
-
-
-
-## Sample Configuration: Legacy
-
-In the past this action performed __both__ steps:
-
-* Generated the artifacts
-* Uploaded the artifacts
-
-That is still possible, but will be removed when actions come out of beta.
-
-For the moment you can continue to work as you did before, add the script `.github/build` to your repository, and configure this action with a pattern of files to upload.
-
-For example the following usage, defined in `.github/workflows/release.yml`, uploads files matching the pattern `puppet-summary-*`.
-
-```
-on:
-  release:
-    types: [created]
-name: Handle Release
-jobs:
-  upload:
-    name: Upload Artifacts
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: Upload
-      uses: skx/github-action-publish-binaries@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        args: 'puppet-summary-*'
-```
-
-We assume that the `.github/build` script generated suitable binaries.  For example a go-based project might create files like this using cross-compilation:
-
-* `puppet-summary-linux-i386`
-* `puppet-summary-linux-amd64`
-* `puppet-summary-darwin-i386`
-* `puppet-summary-darwin-amd64`
-* ....
-
-
-**NOTE**: Please see the note about GITHUB_TOKEN later.
-
 
 ## GITHUB_TOKEN
 
-Your workflow configuration file, named `.github/workflows/release.yml`, will contain a reference to `secrets.GITHUB_TOKEN`, however you do __not__ need to generate that, or update your project settings in any way.
+Your workflow configuration file, named `.github/workflows/release.yml`, will contain a reference to `secrets.GITHUB_TOKEN`, however you do __not__ need to generate that, or update your project settings in any way!
 
 You _can_ inject secrets into workflows, defining them in the project settings, and referring to them by name, but the `GITHUB_TOKEN` value is special and it is handled transparently, requiring no manual setup.

--- a/upload-script
+++ b/upload-script
@@ -26,43 +26,38 @@ fi
 
 
 #
-# In the past we invoked a build-script to generate artifacts.
+# In the past we invoked a build-script to generate the artifacts
+# prior to uploading.
 #
-# Now we prefer to assume they are built already.  However if
-# there is a (legacy) build-script present AND the artifacts
-# we expect to find are missing then we will invoke it.
+# Now we no longer do so, they must exist before they are uploaded.
 #
-if [ -e .github/build ]; then
+# Test for them here.
+#
 
-    # Have we found any artifacts?
-    found=
-    for file in $*; do
-        if [ -e "$file" ]; then
-            found=1
-        fi
-    done
-
-    #
-    # Run the build-script if we have no artifacts.
-    #
-    if [ -z "${found}" ]; then
-
-        echo "************************************************************"
-        echo " artifacts are missing, but a legacy build-script was found."
-        echo " launching build-script .."
-        echo "************************************************************"
-
-        chmod 755 .github/build
-        ./.github/build
-
-        echo "************************************************************"
-        echo " build-script completed"
-        echo "************************************************************"
-    else
-        echo "*****************************************************************"
-        echo " Artifacts are already present, skipping the legacy build-script."
-        echo "*****************************************************************"
+# Have we found any artifacts?
+found=
+for file in $*; do
+    if [ -e "$file" ]; then
+        found=1
     fi
+done
+
+#
+# Abort if missing.
+#
+if [ -z "${found}" ]; then
+
+    echo "*****************************************************************"
+    echo " "
+    echo " Artifacts are missing, and this action no longer invokes the "
+    echo " legacy-build script."
+    echo " "
+    echo " Please see the README.md file for github-action-publish-binaries"
+    echo " which demonstrates how to build AND upload artifacts."
+    echo " "
+    echo "*****************************************************************"
+
+    exit 1
 fi
 
 # Prepare the headers for our curl-command.
@@ -77,9 +72,9 @@ for file in $*; do
     echo "Processing file ${file}"
 
     if [ ! -e "$file" ]; then
-        echo "*****************************"
-        echo " file not present - skipping."
-        echo "*****************************"
+        echo "***************************"
+        echo " file not found - skipping."
+        echo "***************************"
         continue
     fi
 


### PR DESCRIPTION
No longer invoke the legacy build-script.  If the artifacts are missing then do nothing.