### PR TITLE
Change base from golang:latest to debian:buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,9 @@ LABEL repository="http://github.com/skx/github-action-publish-binaries"
 LABEL homepage="http://github.com/skx/github-action-publish-binaries"
 LABEL maintainer="Steve Kemp <steve@steve.fi>"
 
-RUN apt-get update
-RUN apt-get install --yes \
-  ca-certificates \
-  curl \
-  jq
+RUN apt-get update && \
+    apt-get install --yes ca-certificates curl jq && \
+    apt-get clean
 
 COPY upload-script /usr/bin/upload-script
 


### PR DESCRIPTION
Use a different base to create a smaller-sized image, which will close #27.

Starting size:

    frodo ~ $ docker image ls golang:latest
    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
    golang              latest              5f9d35ce5cfe        2 weeks ago         839MB

Updated size:

    frodo ~ $ docker image ls debian:buster
    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
    debian              buster              6d6b00c22231        3 weeks ago         114MB

That should make our image correspondingly smaller.