### PR TITLE
Update docker image to debian:bullseye and reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 LABEL "com.github.actions.name"="github-action-publish-binaries"
 LABEL "com.github.actions.description"="Upload artifacts when new releases are made"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ LABEL maintainer="Steve Kemp <steve@steve.fi>"
 
 RUN apt-get update && \
     apt-get install --yes ca-certificates curl jq && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY upload-script /usr/bin/upload-script
 


### PR DESCRIPTION
Update the base image to debian:bullseye. Bullseye is the new stable release and superseded Buster on 2021-08-14, see https://wiki.debian.org/DebianBuster.

Also reduce the image size by ~13MB by removing the temporary files in `/var/lib/apt/lists`.

Before:
    
    REPOSITORY   TAG                 IMAGE ID       CREATED         SIZE
    <none>       <none>              64306e5b3176   3 minutes ago   146MB
    
After:
    
    REPOSITORY   TAG                 IMAGE ID       CREATED         SIZE
    <none>       <none>              1e14b4f39b75   3 minutes ago   133MB

