### PR TITLE
docs: add note about token write access in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ Here we're explicitly passing the `releaseId` variable, such that the specified 
 
 
 
-## GITHUB_TOKEN
+## `GITHUB_TOKEN`
 
-Your workflow configuration file, named `.github/workflows/release.yml`, will contain a reference to `secrets.GITHUB_TOKEN`, however you do __not__ need to generate that, or update your project settings in any way!
+Your workflow configuration file, named `.github/workflows/release.yml`, will contain a reference to `secrets.GITHUB_TOKEN`, however you do __not__ need to generate that as it is automatically created. You will however need to update your repository settings under `Actions -> General` to give the `GITHUB_TOKEN` write access to upload binaries to the release, without write access you will get a `403` response error.
+
+<img width="894" alt="image" src="https://user-images.githubusercontent.com/19007109/167677568-7c4c942f-b7a3-49af-9470-99605927b123.png">
 
 You _can_ inject secrets into workflows, defining them in the project settings, and referring to them by name, but the `GITHUB_TOKEN` value is special and it is handled transparently, requiring no manual setup.


### PR DESCRIPTION
Without enabling `write` access on the `GITHUB_TOKEN` the upload request returns a 403 such as...

```
***************************
 upload was not successful.
 Aborting
 HTTP status is 403
**********************************
{"message":"Resource not accessible by integration","request_id":"97D2:4ADB:1DD21:5A852:624A9F07","documentation_url":"https://docs.github.com/rest"}
```

![Actions 2022-05-10 at 11 34 09 AM](https://user-images.githubusercontent.com/19007109/167678615-fd8d6908-56ad-4452-a956-78a4f7a2d9dd.jpg)


I think this may be a relatively new option for github actions as I have not seen this before.